### PR TITLE
add dids from issuer-registry

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,7 +1,7 @@
 {
     "meta": {
         "created": "2022-10-27T17:57:31+00:00",
-        "updated": "2025-03-01T23:03:06+00:00"
+        "updated": "2025-03-25T18:29:52+00:00"
     },
     "registry": {
         "did:key:z6MkpLDL3RoAoMRTwTgo3rs39ZwssfaPKtGdZw7AGRN7CK4W": {
@@ -13,6 +13,71 @@
             "name": "Digital Credentials Consortium",
             "location": "Cambridge, MA, USA",
             "url": "https://digitalcredentials.mit.edu"
+        },
+        "did:key:z6MkqEwzA36k2PWsWpeQXjFMzT1PpZuVjZ9W9jd2ZGRb6JKr": {
+            "name": "DCC Sandbox Issuer",
+            "location": "Cambridge, MA, USA",
+            "url": "https://verify.dcconsortium.org"
+        },
+        "did:key:z6MkhVTX9BF3NGYX6cc7jWpbNnR7cAjH8LUffabZP8Qu4ysC": {
+            "name": "DCC Playground",
+            "location": "Cambridge, MA, USA",
+            "url": "https://digitalcredentials.github.io/playground"
+        },
+        "did:key:z6Mkn6E3RLksUuArW6aPXWY6n9Wr5yhjTLEk7vUP448rmj7E": {
+            "name": "MIT xPRO",
+            "location": "Cambridge, MA, USA",
+            "url": "https://xpro.mit.edu"
+        },
+        "did:key:z6MkiUrQooGc3QBsYoDvwGtEdHTaCsaD4zdAyZJsiKr8Lkss": {
+            "name": "MIT xPRO RC",
+            "location": "Cambridge, MA, USA",
+            "url": "https://rc.xpro.mit.edu"
+        },
+        "did:web:digitalcredentials.odl.mit.edu": {
+            "name": "MIT xPRO",
+            "location": "Cambridge, MA, USA",
+            "url": "https://xpro.mit.edu"
+        },
+        "did:web:c21u.gatech.edu": {
+            "name": "Georgia Tech Center for 21st Century Universities",
+            "location": "Atlanta, GA, USA",
+            "url": "https://c21u.gatech.edu"
+        },
+        "did:web:credentials.mcmaster.ca": {
+            "name": "McMaster University Digital Credentialing Pilot",
+            "location": "Hamilton, ON, Canada",
+            "url": "https://credentials.mcmaster.ca"
+        },
+        "did:web:dibiho.org:TUM": {
+            "name": "Technical University of Munich",
+            "location": "Munich, Germany",
+            "url": "https://www.it.tum.de/it/dibiho/"
+        },
+        "did:web:dibiho.org:TUM.Test": {
+            "name": "Technical University of Munich",
+            "location": "Munich, Germany",
+            "url": "https://www.it.tum.de/it/dibiho/"
+        },
+        "did:web:dibiho.org:HPI": {
+            "name": "openHPI",
+            "location": "Potsdam, Germany",
+            "url": "https://staging.openhpi.de"
+        },
+        "did:web:staging.openhpi.de": {
+            "name": "openHPI",
+            "location": "Potsdam, Germany",
+            "url": "https://staging.openhpi.de"
+        },
+        "did:key:z6MkmZYh1qm9S4MLYdrue8z6TSA2XVe9Zi49h4KRgASwbQf1": {
+            "name": "MIT Jameel World Education Lab",
+            "location": "Cambridge, MA, USA",
+            "url": "https://jwel.mit.edu"
+        },
+        "did:key:z6MkjSdgaUNWTQsH8RbkrNoxk98ZA2FHQsyEFEcHAEGhk3dB": {
+            "name": "Instituto Tecnológico de Monterrey Test",
+            "location": "Monterrey, Nuevo León, México",
+            "url": "https://tec.mx/es"
         }
     }
 }


### PR DESCRIPTION
Adds dids from the soon-to-be-archived issuer-registry: https://github.com/digitalcredentials/issuer-registry/blob/main/registry.json

Hold off merging this until mar 26.

Addresses https://github.com/digitalcredentials/ops/issues/31